### PR TITLE
Usage of code location as advised by Blackduck support

### DIFF
--- a/synopsys-detect
+++ b/synopsys-detect
@@ -156,7 +156,9 @@ set_scan_vars_ci_build() {
   local project_name="$1"
   local branch_name="$2"
   HUB_DETECT_ARGS+=("--detect.project.name=${project_name}")
-  HUB_DETECT_ARGS+=("--detect.code.location.name=${project_name}_${branch_name}_${timestamp}")
+  HUB_DETECT_ARGS+=("--detect.code.location.name=${project_name}_${branch_name}")
+  HUB_DETECT_ARGS+=("--detect.code.location.prefix=${timestamp}")
+  HUB_DETECT_ARGS+=("--detect.code.location.unmap=true")
   HUB_DETECT_ARGS+=("--detect.project.version.name=${branch_name}")
   HUB_DETECT_ARGS+=("--detect.project.version.phase=development")
   ret_val=2


### PR DESCRIPTION
Use codelocation prefix to uniquely name
unmap prior versions of project when running new scan