### PR TITLE
sig-repo synopsys instead of blackducksoftware

### DIFF
--- a/synopsys-detect
+++ b/synopsys-detect
@@ -93,7 +93,7 @@ get_hub_detect_jar() {
     mkdir -p "${DETECT_JAR_PATH}"
   fi
 
-  DETECT_SOURCE="https://repo.blackducksoftware.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-detect/${DETECT_VERSION}/synopsys-detect-${DETECT_VERSION}.jar"
+  DETECT_SOURCE="https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-detect/${DETECT_VERSION}/synopsys-detect-${DETECT_VERSION}.jar"
   DETECT_FILENAME=$(awk -F "/" '{print $NF}' <<< ${DETECT_SOURCE})
   DETECT_PATH="${DETECT_JAR_PATH}/${DETECT_FILENAME}"
 


### PR DESCRIPTION
Change from blackducksofware dns entry for artifactory

https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-detect/6.7.0/