### PR TITLE
Replace or remove deprecated properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To enable the scan, add the command below to your CircleCI config file (usually 
           ci-build ${CIRCLE_PROJECT_USERNAME}_${CIRCLE_PROJECT_REPONAME} ${CIRCLE_BRANCH} \
           --logging.level.com.synopsys.integration=DEBUG  \
           --detect.notices.report=true \
-          --detect.report.timeout=480
+          --detect.timeout=480
 ```
 ### Enabling scan in Azure
 
@@ -76,7 +76,7 @@ This is a more complex multi-part scan taken from the open source DAML repo, whi
           --detect.bazel.target=//... \
           --detect.bazel.dependency.type=haskell_cabal_library \
           --detect.notices.report=true \
-          --detect.report.timeout=1500
+          --detect.timeout=1500
         displayName: 'Blackduck Haskell Scan'
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
@@ -99,7 +99,7 @@ This is a more complex multi-part scan taken from the open source DAML repo, whi
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
-          --detect.report.timeout=4500
+          --detect.timeout=4500
         displayName: 'Blackduck Scan'
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
@@ -215,7 +215,7 @@ ci-build <github_org_of_project>_<github_repo_of_project> <branch_name> \
 --detect.bazel.target=//... \
 --detect.bazel.dependency.type=haskell_cabal_library \
 --detect.notices.report=true \
---detect.report.timeout=1500
+--detect.timeout=1500
 ```
 
 ## Bazel JVM Scan
@@ -230,7 +230,7 @@ ci-build <github_org_of_project>_<github_repo_of_project> <branch_name> \
 --detect.bazel.target=//... \
 --detect.bazel.dependency.type=maven_install \
 --detect.notices.report=true \
---detect.report.timeout=1500
+--detect.timeout=1500
 ```
 
 ### Reference on all scan properties

--- a/synopsys-detect
+++ b/synopsys-detect
@@ -203,7 +203,6 @@ HUB_DETECT_ARGS=("--blackduck.timeout=${HUB_DETECT_TIMEOUT}")
 #HUB_DETECT_ARGS+=("--detect.blackduck.signature.scanner.parallel.processors=-1")
 HUB_DETECT_ARGS+=("--detect.parallel.processors=0")
 HUB_DETECT_ARGS+=("--detect.detector.search.depth=${HUB_DETECT_DETECTOR_SEARCH_DEPTH}")
-HUB_DETECT_ARGS+=("--detect.blackduck.signature.scanner.exclusion.pattern.search.depth=${HUB_DETECT_DETECTOR_SEARCH_DEPTH}")
 
 check_args "$@"
 set_scan_vars "$@"

--- a/synopsys-detect
+++ b/synopsys-detect
@@ -46,9 +46,8 @@ HUB_DETECT_JAVA_OPTS=${DETECT_JAVA_OPTS:-}
 # URL for our Black Duck
 HUB_DETECT_URL="https://digitalasset.blackducksoftware.com/"
 
-# Timeout to wait for connections to Black Duck to complete. The Hub Detect tool
-# default is 120 seconds.
-HUB_DETECT_TIMEOUT="60"
+# Timeout to wait for connections to Black Duck to complete.
+HUB_DETECT_TIMEOUT="1200"
 
 # The depth from directory this script is run from to search for files (such as
 # manifest files) for detectors to publish
@@ -199,9 +198,7 @@ run_hub_detect() {
   fi
 }
 
-HUB_DETECT_ARGS=("--detect.timeout=${HUB_DETECT_TIMEOUT}")
-#HUB_DETECT_ARGS+=("--detect.blackduck.signature.scanner.parallel.processors=-1")
-HUB_DETECT_ARGS+=("--detect.parallel.processors=0")
+HUB_DETECT_ARGS=("--detect.parallel.processors=0")
 HUB_DETECT_ARGS+=("--detect.detector.search.depth=${HUB_DETECT_DETECTOR_SEARCH_DEPTH}")
 
 check_args "$@"

--- a/synopsys-detect
+++ b/synopsys-detect
@@ -199,7 +199,7 @@ run_hub_detect() {
   fi
 }
 
-HUB_DETECT_ARGS=("--blackduck.timeout=${HUB_DETECT_TIMEOUT}")
+HUB_DETECT_ARGS=("--detect.timeout=${HUB_DETECT_TIMEOUT}")
 #HUB_DETECT_ARGS+=("--detect.blackduck.signature.scanner.parallel.processors=-1")
 HUB_DETECT_ARGS+=("--detect.parallel.processors=0")
 HUB_DETECT_ARGS+=("--detect.detector.search.depth=${HUB_DETECT_DETECTOR_SEARCH_DEPTH}")


### PR DESCRIPTION
Address deprecated properties from Hub Detect 6.8.0  Release Notes
https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/642351242/Releases+Notes#Changed-features
`
Changed features

- Added the detect.timeout property to consolidate the functionality of blackduck.timeout and detect.report.timeout.
- Deprecated the blackduck.timeout and detect.report.timeout properties, which are consolidated into the detect.timeout property.
- Added the latest scan date for a project version to the risk report PDF file.
- Deprecated all Detect exclusion properties. Future releases will feature a new property to extend and consolidate these properties.
- Deprecated all Detect signature scanner properties. Future releases will feature an alternative mechanism for providing signature scanner arguments to Detect.
- Deprecated the detect.resolve.tilde.in.paths property. Resolving tildes is a shell feature which Detect will not support in a future version.
- Deprecated the detect.python.python3 property because of the January 2020 sunset of Python 2; this property (which toggles between searching for a 'python' and 'python3' executable) is no longer necessary. Refer to: PEP-394
- Deprecated the detect.docker.inspector.air.gap.path, detect.gradle.inspector.air.gap.path, and detect.nuget.inspector.air.gap.path properties to simplify using Detect.
- Deprecated the detect.default.project.version.scheme, detect.default.project.version.text, and detect.default.project.version.timeformat properties to simplify using Detect.
- Deprecated the blackduck.username and blackduck.password properties. Users should use a Black Duck API token for authentication.
