### PR TITLE
upgrade to synopsys 8.2.0

### DIFF
--- a/synopsys-detect
+++ b/synopsys-detect
@@ -33,7 +33,7 @@ ci-release scan type arguments:
 DETECT_VERSION="7.14.0"
 
 # SHA-256 checksum of Synopsys Detect jar
-DETECT_SHA256_SUM="1f3c580dbacc9bf55854e3af21c4dfc6ca40ec446f225c355581f70201619ded  synopsys-detect-7.14.0.jar"
+DETECT_SHA256_SUM="c93390fcf7560141b68a520783b2a1aa726d72c930fe12e56bb3a63f4b0784f1  synopsys-detect-8.2.0.jar"
 
 # The local directory for the Hub Direct JAR
 DETECT_JAR_PATH="${HOME}/blackduck/bin"

--- a/synopsys-detect
+++ b/synopsys-detect
@@ -30,7 +30,7 @@ ci-release scan type arguments:
 "
 
 # Version to use
-DETECT_VERSION="7.14.0"
+DETECT_VERSION="8.2.0"
 
 # SHA-256 checksum of Synopsys Detect jar
 DETECT_SHA256_SUM="c93390fcf7560141b68a520783b2a1aa726d72c930fe12e56bb3a63f4b0784f1  synopsys-detect-8.2.0.jar"


### PR DESCRIPTION
Newest version of synopsys-detect is released

[8.2.0](https://github.com/blackducksoftware/synopsys-detect/releases/tag/8.2.0)
Repository: [blackducksoftware/synopsys-detect](https://github.com/blackducksoftware/synopsys-detect) · Tag: [8.2.0](https://github.com/blackducksoftware/synopsys-detect/tree/8.2.0) · Commit: [43e8fe5](https://github.com/blackducksoftware/synopsys-detect/commit/43e8fe5eaac940a1cf1259d9e4e748b1d68828a1) · Released by: [blackduck-serv-builder](https://github.com/blackduck-serv-builder)

Released from Jenkins on Oct 25, 2022 11:08:58

—
This release has 2 assets:

Source code (zip)
Source code (tar.gz)
Visit the [release page](https://github.com/blackducksoftware/synopsys-detect/releases/tag/8.2.0) to download them.

—
You are receiving this because you are watching this repository.
[View it on GitHub](https://github.com/blackducksoftware/synopsys-detect/releases/tag/8.2.0) or [unsubscribe](https://github.com/blackducksoftware/synopsys-detect/unsubscribe_via_email/AGADHCNMRL7RHE5MK6KOJGLWE7ZZNANCNFSM4CRKNGRQ) from all notifications for this repository.