### PR TITLE
upgrade to synopsys detect 8.9.0

### DIFF
--- a/synopsys-detect
+++ b/synopsys-detect
@@ -30,10 +30,10 @@ ci-release scan type arguments:
 "
 
 # Version to use
-DETECT_VERSION="8.7.0"
+DETECT_VERSION="8.9.0"
 
 # SHA-256 checksum of Synopsys Detect jar
-DETECT_SHA256_SUM="0d9013cef07eeca5fca27a4975a3e6e33b094b53fa817bbd79a7d7ba7d0c97aa  synopsys-detect-8.7.0.jar"
+DETECT_SHA256_SUM="ab87ccdaa8c2fc5420a35fbd28c710dfe3647ca7ba851b1a7333543c79053588  synopsys-detect-8.9.0.jar"
 
 # The local directory for the Hub Direct JAR
 DETECT_JAR_PATH="${HOME}/blackduck/bin"


### PR DESCRIPTION
https://community.synopsys.com/s/question/0D5Hr00006WwZVHKA3/synopsys-detect-890-for-black-duck-has-been-released

This includes an auto version updating feature but since we have all our pipelines sharing one common shell script that forces the newer version I don't think we need it, though it may be an interesting alternative approach 

![image](https://github.com/DACH-NY/security-blackduck/assets/25179017/69678286-26dd-4edd-a3c3-e3574364f5e9)
