### PR TITLE
fix script outside of CircleCI

### DIFF
--- a/synopsys-detect
+++ b/synopsys-detect
@@ -201,7 +201,7 @@ run_hub_detect() {
 HUB_DETECT_ARGS=("--detect.parallel.processors=0")
 HUB_DETECT_ARGS+=("--detect.detector.search.depth=${HUB_DETECT_DETECTOR_SEARCH_DEPTH}")
 
-if [ -n "${CIRCLE_PROJECT_REPONAME}" ] && [ -n "${CIRCLE_PROJECT_USERNAME}" ]; then
+if [ -n "${CIRCLE_PROJECT_REPONAME:-}" ] && [ -n "${CIRCLE_PROJECT_USERNAME:-}" ]; then
 	HUB_DETECT_ARGS+=("--detect.custom.fields.version[0].label=codeRepoName")
 	HUB_DETECT_ARGS+=("--detect.custom.fields.version[0].value=${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}")
 fi


### PR DESCRIPTION
This line currently fails on Azure Pipelines because those env vars are not set and `nounset` is true (`set -u`). Example failing [build].

[build]: https://dev.azure.com/digitalasset/daml/_build/results?buildId=161281&view=logs&j=f6d54466-9c7f-5de5-798e-e30bc1a58729